### PR TITLE
Added ability to disable paypal button

### DIFF
--- a/components/Button.vue
+++ b/components/Button.vue
@@ -3,14 +3,37 @@
     <div style="color: red;">
       {{ $t(message) }}
     </div>
-    <div class="paypal-button" />
+    <div v-if="disabled">
+      <div class="paypal-button disabled-overlay" />
+    </div>
+    <div v-else>
+      <div class="paypal-button" />
+    </div>
   </div>
 </template>
 
+<style>
+.disabled-overlay {
+    position: relative;
+    margin-bottom: -8px;
+    content: '';
+    width: 100%;
+    height: 100%;
+    background-color: white;
+    opacity: .3;
+    z-index: 1000;
+}
+</style>
 <script>
 import { PaypalButton } from './PaypalButton'
 
 export default {
-  mixins: [PaypalButton]
+  mixins: [PaypalButton],
+  props: {
+    disabled: {
+      type: Boolean,
+      default: false
+    }
+  }
 }
 </script>

--- a/components/Button.vue
+++ b/components/Button.vue
@@ -22,6 +22,7 @@
     background-color: white;
     opacity: .3;
     z-index: 1000;
+    pointer-events: none;
 }
 </style>
 <script>

--- a/components/PaypalButton.js
+++ b/components/PaypalButton.js
@@ -12,6 +12,10 @@ export const PaypalButton = {
         shape: 'rect',
         label: 'paypal'
       })
+    },
+    disabled: {
+      type: Boolean,
+      default: false
     }
   },
   computed: {
@@ -26,11 +30,19 @@ export const PaypalButton = {
     // We use the SDK to render the PayPal Button.
     //
     renderButton () {
-      window.paypal.Buttons({
-        createOrder: this.onCreateOrder,
-        onApprove: this.onApprove,
-        style: this.styling
-      }).render('.paypal-button')
+      if (this.disabled) {
+        window.paypal.Buttons({
+          createOrder: null,
+          onApprove: null,
+          style: this.styling
+        }).render('.paypal-button')
+      } else {
+        window.paypal.Buttons({
+          createOrder: this.onCreateOrder,
+          onApprove: this.onApprove,
+          style: this.styling
+        }).render('.paypal-button')
+      }
     },
 
     //

--- a/components/PaypalButton.js
+++ b/components/PaypalButton.js
@@ -12,10 +12,6 @@ export const PaypalButton = {
         shape: 'rect',
         label: 'paypal'
       })
-    },
-    disabled: {
-      type: Boolean,
-      default: false
     }
   },
   computed: {
@@ -30,19 +26,11 @@ export const PaypalButton = {
     // We use the SDK to render the PayPal Button.
     //
     renderButton () {
-      if (this.disabled) {
-        window.paypal.Buttons({
-          createOrder: null,
-          onApprove: null,
-          style: this.styling
-        }).render('.paypal-button')
-      } else {
-        window.paypal.Buttons({
-          createOrder: this.onCreateOrder,
-          onApprove: this.onApprove,
-          style: this.styling
-        }).render('.paypal-button')
-      }
+      window.paypal.Buttons({
+        createOrder: this.onCreateOrder,
+        onApprove: this.onApprove,
+        style: this.styling
+      }).render('.paypal-button')
     },
 
     //


### PR DESCRIPTION
Added disabled property which receives an argument from o-confirm-order
Added disabled overlay to grey out the button
When disabled is true, the overlay will be used on the button and the button will not call the methods which trigger the paypal window to pop up 
![image](https://user-images.githubusercontent.com/17791285/133531421-e98b68b9-6442-4463-b84b-0b8302c73738.png)
![image](https://user-images.githubusercontent.com/17791285/133530669-589d82bd-7edf-40ba-8cbd-34767bb4f75c.png)
